### PR TITLE
Change the /add commit to use the authenticated user

### DIFF
--- a/prdeploy-webhooks/src/services/deploy-service.ts
+++ b/prdeploy-webhooks/src/services/deploy-service.ts
@@ -206,11 +206,7 @@ export class DeployService {
         message: `Adding ${service} to pull request build.`,
         content: base64Content,
         branch: pullRequest.head.ref,
-        sha,
-        committer: {
-          name: 'Gregg B. Jensen',
-          email: 'greggbjensen@users.noreply.github.com'
-        }
+        sha
       });
     }
 


### PR DESCRIPTION
I believe if we remove the `committer` parameter, it will use the authenticated user instead, which in this case I believe would be the PR deploy app. The GitHub docs seem to indicate that this field is optional.

![image](https://github.com/user-attachments/assets/a10adcdf-ffa6-4212-afe1-99cfd61a2dfd)

I'm hoping this change will update the commits when we run an `/add some-app` command to show up as our PR deploy app instead.