### PR TITLE
Fix JSON template rendering for pull request titles containing special characters

### DIFF
--- a/prdeploy-webhooks/src/services/template-service.ts
+++ b/prdeploy-webhooks/src/services/template-service.ts
@@ -6,6 +6,10 @@ Handlebars.registerHelper('jsonEncode', (text: string) => {
   return JSON.stringify(text);
 });
 
+Handlebars.registerHelper('jsonEncodeUnquoted', (text: string) => {
+  return JSON.stringify(text).slice(1, -1);
+});
+
 Handlebars.registerHelper('color', hexValue => (hexValue ? hexValue.replace(/^#/, '') : ''));
 
 export type TemplateNames =

--- a/prdeploy-webhooks/templates/deploy-completed.json
+++ b/prdeploy-webhooks/templates/deploy-completed.json
@@ -18,7 +18,7 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "<{{pull.html_url}}|#{{pull.number}}> {{{pull.title}}}"
+                "text": "<{{pull.html_url}}|#{{pull.number}}> {{{jsonEncodeUnquoted pull.title}}}"
             }
         },
         {

--- a/prdeploy-webhooks/templates/deploy-released.json
+++ b/prdeploy-webhooks/templates/deploy-released.json
@@ -18,7 +18,7 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "<{{pull.html_url}}|#{{pull.number}}> {{{pull.title}}}"
+                "text": "<{{pull.html_url}}|#{{pull.number}}> {{{jsonEncodeUnquoted pull.title}}}"
             }
         },
         {

--- a/prdeploy-webhooks/templates/pull-request-merge-conflicts.json
+++ b/prdeploy-webhooks/templates/pull-request-merge-conflicts.json
@@ -18,7 +18,7 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "<{{pull.html_url}}|#{{pull.number}}> {{{pull.title}}}"
+        "text": "<{{pull.html_url}}|#{{pull.number}}> {{{jsonEncodeUnquoted pull.title}}}"
       }
     }
   ]

--- a/prdeploy-webhooks/test/services/template-service.spec.ts
+++ b/prdeploy-webhooks/test/services/template-service.spec.ts
@@ -17,7 +17,7 @@ describe('renderQueueTable', () => {
     expect(result).not.toBeFalsy();
     expect(result).toMatch(`| Position | 1       | 2       | 3       |
 |----------|---------|---------|---------|
-| [dev queue](https://awssite/deployments/greggbjensen/prdeploy-example-repo?environment=dev) | [2987](https://github.com/greggbjensen/prdeploy-example-repo/pull/2987) | [2549](https://github.com/greggbjensen/prdeploy-example-repo/pull/2549) | [2391](https://github.com/greggbjensen/prdeploy-example-repo/pull/2391) |`);
+| [dev queue](https://awssite/deployments/greggbjensen/prdeploy-example-repo/deployments?environment=dev) | [2987](https://github.com/greggbjensen/prdeploy-example-repo/pull/2987) | [2549](https://github.com/greggbjensen/prdeploy-example-repo/pull/2549) | [2391](https://github.com/greggbjensen/prdeploy-example-repo/pull/2391) |`);
   });
 });
 
@@ -71,6 +71,11 @@ Pull request with fix and feature.
 
   it('renders JSON template with escaping', async () => {
     const service = container.resolve(TemplateService);
+    const pull = {
+      html_url: 'https://github.com/greggbjensen/prdeploy-example-repo/pull/2987',
+      number: 2987,
+      title: 'This pull request title has some "special" characters'
+    };
     const slackPullBody = `
 This pull request body includes multiple
 new lines and " these things...
@@ -78,6 +83,7 @@ Oh and another one"
 `;
 
     const result = await service.render('deploy-released.json', {
+      pull,
       slackPullBody
     });
 


### PR DESCRIPTION
This change is intended to resolve an issue where deploy / release messages fail to get posted due to invalid JSON. It's caused by pull requests that have special characters in the title that need to be escaped. I saw that we already had a `jsonEncode` Handlebars helper function, so I added another one that also removes the surrounding quotes so that the value is valid in the JSON.