### PR TITLE
change placeholder image service

### DIFF
--- a/prdeploy-webhooks/templates/deploy-completed.json
+++ b/prdeploy-webhooks/templates/deploy-completed.json
@@ -5,7 +5,7 @@
             "elements": [
                 {
                   "type": "image",
-                  "image_url": "https://via.placeholder.com/32/{{color environment.color}}/ffffff?text={{environment.name}}",
+                  "image_url": "https://placehold.co/32x32/{{color environment.color}}/ffffff/png?text={{environment.name}}",
                   "alt_text": "{{environment.name}}"
                 },
                 {

--- a/prdeploy-webhooks/templates/deploy-nothing-found.json
+++ b/prdeploy-webhooks/templates/deploy-nothing-found.json
@@ -5,7 +5,7 @@
       "elements": [
         {
           "type": "image",
-          "image_url": "https://via.placeholder.com/32/{{color environment.color}}/ffffff?text={{environment.name}}",
+          "image_url": "https://placehold.co/32x32/{{color environment.color}}/ffffff/png?text={{environment.name}}",
           "alt_text": "{{environment.name}}"
         },
         {

--- a/prdeploy-webhooks/templates/deploy-released.json
+++ b/prdeploy-webhooks/templates/deploy-released.json
@@ -5,7 +5,7 @@
             "elements": [
                 {
                     "type": "image",
-                    "image_url": "https://via.placeholder.com/32/{{color environment.color}}/ffffff?text={{environment.name}}",
+                    "image_url": "https://placehold.co/32x32/{{color environment.color}}/ffffff/png?text={{environment.name}}",
                     "alt_text": "{{environment.name}}"
                 },
                 {

--- a/prdeploy-webhooks/templates/environment-approval-required.json
+++ b/prdeploy-webhooks/templates/environment-approval-required.json
@@ -5,7 +5,7 @@
       "elements": [
         {
           "type": "image",
-          "image_url": "https://via.placeholder.com/32/{{color environment.color}}/ffffff?text={{environment.name}}",
+          "image_url": "https://placehold.co/32x32/{{color environment.color}}/ffffff/png?text={{environment.name}}",
           "alt_text": "{{environment.name}}"
         },
         {

--- a/prdeploy-webhooks/templates/environment-available.json
+++ b/prdeploy-webhooks/templates/environment-available.json
@@ -5,7 +5,7 @@
       "elements": [
         {
           "type": "image",
-          "image_url": "https://via.placeholder.com/32/{{color environment.color}}/ffffff?text={{environment.name}}",
+          "image_url": "https://placehold.co/32x32/{{color environment.color}}/ffffff/png?text={{environment.name}}",
           "alt_text": "{{environment.name}}"
         },
         {

--- a/prdeploy-webhooks/templates/pull-request-merge-conflicts.json
+++ b/prdeploy-webhooks/templates/pull-request-merge-conflicts.json
@@ -5,7 +5,7 @@
       "elements": [
         {
           "type": "image",
-          "image_url": "https://via.placeholder.com/32/{{color environment.color}}/ffffff?text={{environment.name}}",
+          "image_url": "https://placehold.co/32x32/{{color environment.color}}/ffffff/png?text={{environment.name}}",
           "alt_text": "{{environment.name}}"
         },
         {


### PR DESCRIPTION
Apparently the `via.placeholder.com` image service we were using no longer exists.

https://github.com/IchHabRecht/filefill/issues/87
https://github.com/faker-js/faker/issues/2477

I found a similar one that we can use to maintain the same functionality.