### PR TITLE
added Unauthorized error handling to error filter / response formatter

### DIFF
--- a/prdeploy-api/src/PrDeploy.Api/Filters/SanitizedErrorFilter.cs
+++ b/prdeploy-api/src/PrDeploy.Api/Filters/SanitizedErrorFilter.cs
@@ -41,6 +41,16 @@ namespace PrDeploy.Api.Filters
                                     null, HttpStatusCode.Forbidden))
                             .Build();
                     }
+                    else if (requestException.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        result = ErrorBuilder.FromError(error)
+                            .SetCode("UNAUTHORIZED")
+                            .SetMessage("Authentication required.")
+                            .SetException(
+                                new HttpRequestException("Authentication required.",
+                                    null, HttpStatusCode.Unauthorized))
+                            .Build();
+                    }
                     break;
 
                 case ValidationException validationException:
@@ -53,7 +63,6 @@ namespace PrDeploy.Api.Filters
                                 null, HttpStatusCode.BadRequest))
                         .Build();
                     break;
-
             }
 
             _logger.LogError(error.Exception, error.Message, error);

--- a/prdeploy-api/src/PrDeploy.Api/Filters/SanitizedHttpResponseFormatter.cs
+++ b/prdeploy-api/src/PrDeploy.Api/Filters/SanitizedHttpResponseFormatter.cs
@@ -11,9 +11,14 @@ namespace PrDeploy.Api.Filters
             var statusCode = base.OnDetermineStatusCode(result, format, proposedStatusCode);
             if (result.Errors?.Count > 0)
             {
+                if (result.Errors.Any(e => e.Code == "UNAUTHORIZED"))
+                {
+                    return HttpStatusCode.Unauthorized;
+                }
+
                 if (result.Errors.Any(e => e.Code == "FORBIDDEN"))
                 {
-                    statusCode = HttpStatusCode.Forbidden;
+                    return HttpStatusCode.Forbidden;
                 }
             }
 


### PR DESCRIPTION
When the user's session expires, we have some logic to log the user out to trigger the login page. When this happens, there's a bit of a race condition and a GraphQL request is made right after with no access token. We're not handling the error that comes back, so it shows up as an HTTP 500.