### PR TITLE
Fix auth issues after .NET 9 upgrade

### DIFF
--- a/prdeploy-api/prdeploy-api.sln
+++ b/prdeploy-api/prdeploy-api.sln
@@ -20,6 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{2D34
 		scripts\GraphQlScaffold.ps1 = scripts\GraphQlScaffold.ps1
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/prdeploy-api/src/PrDeploy.Api/Auth/AuthenticationExtensions.cs
+++ b/prdeploy-api/src/PrDeploy.Api/Auth/AuthenticationExtensions.cs
@@ -1,9 +1,7 @@
-﻿using System.IdentityModel.Tokens.Jwt;
-using System.Text;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using PrDeploy.Api.Business.Options;
-using JwtRegisteredClaimNames = System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames;
+using System.Text;
 
 namespace PrDeploy.Api.Auth
 {
@@ -17,8 +15,6 @@ namespace PrDeploy.Api.Auth
 
             var jwtOptions = new JwtOptions();
             configureJwt(jwtOptions);
-
-            JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
             services
                 .AddAuthentication(options =>
@@ -41,6 +37,7 @@ namespace PrDeploy.Api.Auth
                             ValidateLifetime = true,
                             ValidateIssuerSigningKey = true
                         };
+                        o.MapInboundClaims = false;
                     });
 
             return services;

--- a/prdeploy-api/src/PrDeploy.Api/Auth/GitHubAuthenticationHandler.cs
+++ b/prdeploy-api/src/PrDeploy.Api/Auth/GitHubAuthenticationHandler.cs
@@ -17,9 +17,8 @@ namespace PrDeploy.Api.Auth
             IOptionsMonitor<JwtBearerOptions> options, 
             ILoggerFactory logger, 
             UrlEncoder encoder,
-            ISystemClock clock, 
             ICipherService cipherService)
-            : base(options, logger, encoder, clock)
+            : base(options, logger, encoder)
         {
             _cipherService = cipherService;
         }


### PR DESCRIPTION
The logic we had for clearing inbound claims to avoid the `sub` claim getting mapped was no longer working. There's a new option to turn off mapping inbound claims, which seemed a little nicer.

Also fixed an issue with a deprecated constructor param for the auth handler.